### PR TITLE
ROI Physical Activity Timestamp Updates

### DIFF
--- a/js/pages/reports.js
+++ b/js/pages/reports.js
@@ -276,7 +276,7 @@ const initializeReadButtons = () => {
                         [fieldMapping.reports.physicalActivity.status]: fieldMapping.reports.declined
                     }
                 };
-                if (!myData[fieldMapping.reports.physicalActivityReport] || (myData[fieldMapping.reports.physicalActivityReport] && !myData[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.declinedTS])) {
+                if (!myData[fieldMapping.reports.physicalActivityReport] || !myData[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.declinedTS]) {
                     obj[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.declinedTS] = currentTime.toISOString();
                 }
                 await storeResponse(myData[fieldMapping.reports.physicalActivityReport] ? { [fieldMapping.reports.physicalActivityReport]: Object.assign({}, myData[fieldMapping.reports.physicalActivityReport], obj[fieldMapping.reports.physicalActivityReport]) } : obj);
@@ -337,7 +337,7 @@ const initializeDeclinedButtons = () => {
                         [fieldMapping.reports.physicalActivity.status]: fieldMapping.reports.viewed
                     }
                 };
-                if (!myData[fieldMapping.reports.physicalActivityReport] || (myData[fieldMapping.reports.physicalActivityReport] && !myData[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.viewedTS])) {
+                if (!myData[fieldMapping.reports.physicalActivityReport] || !myData[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.viewedTS]) {
                     obj[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.viewedTS] = currentTime.toISOString();
                 }
                 await storeResponse(myData[fieldMapping.reports.physicalActivityReport] ? { [fieldMapping.reports.physicalActivityReport]: Object.assign({}, myData[fieldMapping.reports.physicalActivityReport], obj[fieldMapping.reports.physicalActivityReport]) } : obj);

--- a/js/pages/reports.js
+++ b/js/pages/reports.js
@@ -273,10 +273,12 @@ const initializeReadButtons = () => {
                 let currentTime = new Date();
                 let obj = {
                     [fieldMapping.reports.physicalActivityReport]: {
-                        [fieldMapping.reports.physicalActivity.status]: fieldMapping.reports.declined,
-                        [fieldMapping.reports.physicalActivity.declinedTS]: currentTime.toISOString()
+                        [fieldMapping.reports.physicalActivity.status]: fieldMapping.reports.declined
                     }
                 };
+                if (!myData[fieldMapping.reports.physicalActivityReport] || (myData[fieldMapping.reports.physicalActivityReport] && !myData[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.declinedTS])) {
+                    obj[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.declinedTS] = currentTime.toISOString();
+                }
                 await storeResponse(myData[fieldMapping.reports.physicalActivityReport] ? { [fieldMapping.reports.physicalActivityReport]: Object.assign({}, myData[fieldMapping.reports.physicalActivityReport], obj[fieldMapping.reports.physicalActivityReport]) } : obj);
                 window.location.reload();
             });
@@ -335,6 +337,9 @@ const initializeDeclinedButtons = () => {
                         [fieldMapping.reports.physicalActivity.status]: fieldMapping.reports.viewed
                     }
                 };
+                if (!myData[fieldMapping.reports.physicalActivityReport] || (myData[fieldMapping.reports.physicalActivityReport] && !myData[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.viewedTS])) {
+                    obj[fieldMapping.reports.physicalActivityReport][fieldMapping.reports.physicalActivity.viewedTS] = currentTime.toISOString();
+                }
                 await storeResponse(myData[fieldMapping.reports.physicalActivityReport] ? { [fieldMapping.reports.physicalActivityReport]: Object.assign({}, myData[fieldMapping.reports.physicalActivityReport], obj[fieldMapping.reports.physicalActivityReport]) } : obj);
                 window.location.reload();
             });


### PR DESCRIPTION
Updates to handle viewing after declining and declining multiple times.  The timestamp should represent the first time the event happened and not updated after it is recorded.