### PR TITLE
Updated Verification Message to be subordinate to Data Destruction and Consent Withdrawn

### DIFF
--- a/js/components/navbar.js
+++ b/js/components/navbar.js
@@ -3,7 +3,7 @@ import fieldMapping from '../fieldToConceptIdMapping.js';
 
 export const userNavBar = (response) => {
     const disabledClass = isParticipantDataDestroyed(response.data) ? 'disabled': '';
-    const hiddenClass = response.code === 200 && response.data['699625233'] === 353358909 && response.data['919254129'] === 353358909 ? '': 'hidden';
+    const hiddenClass = response.code === 200 && response.data[fieldMapping.userProfileSubmittedAutogen] === fieldMapping.yes && response.data[fieldMapping.consentSubmitted] === fieldMapping.yes ? '': 'hidden';
 
     let template = translateHTML(`
         <ul class="navbar-nav">

--- a/js/event.js
+++ b/js/event.js
@@ -2044,7 +2044,7 @@ const verifyUserDetails = (formData) => {
     document.getElementById('confirmReview').addEventListener('click', async () => {
         const modal = bootstrap.Modal.getInstance(document.getElementById('connectMainModal'));
         dataSavingBtn('save-data');
-        formData['699625233'] = 353358909;
+        formData[fieldMapping.userProfileSubmittedAutogen] = fieldMapping.yes;
         formData['430551721'] = new Date().toISOString();
 
         const { formerdata } = formData[fieldMapping.userProfileHistory];

--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -70,9 +70,20 @@ export default
     "altContactHomePhone": 318130543,
     "altContactEmail": 750097000,
 
+    "recruitmentType": 512820379,
+    "recruitmentTypeNotActive": 180583933,
+    "recruitmentTypeActive": 486306141,
+    "recruitmentTypePassive": 854703046,
+
     "healthcareProvider":827220437,
+
     "verification":821247024,
+    "notYetVerified": 875007964,
     "verified":197316935,
+    "cannotBeVerified": 219863910,
+    "duplicate": 922622075,
+    "outreachTimedOut": 160161595,
+
     "verifiedDate": 914594314,
     "firebaseAuthEmail": 421823980,
     "firebaseAuthPhone": 348474836,
@@ -80,6 +91,7 @@ export default
     "yes": 353358909,
     "no": 104430631,
     "consentVersion": 454205108,
+    "consentSubmitted": 919254129,
     "hipaaVersion": 412000022,
     "hipaaRevokeVersion": 407743866,
     "dataDestructionVersion": 304438543,
@@ -92,7 +104,7 @@ export default
     "requestedDataDestroyNotSigned": 111959410,
     "requestedDataDestroySigned": 704529432,
     "noneOfTheseApply": 398561594,
-    "outreachTimedOut": 160161595,
+    
     firstSignInFlag: 230663853,
     firstSignInTime: 335767902,
     hipaaTimestamp: 262613359,

--- a/js/pages/agreements.js
+++ b/js/pages/agreements.js
@@ -239,7 +239,7 @@ export const renderAgreements = async () => {
     showAnimation();
     const myData = await getMyData();
     let template = '';
-    if(hasUserData(myData) && myData.data['919254129'] !== undefined && myData.data['919254129'] === fieldMapping.yes){
+    if (hasUserData(myData) && myData.data[fieldMapping.consentSubmitted] !== undefined && myData.data[fieldMapping.consentSubmitted] === fieldMapping.yes) {
         template += translateHTML(`
             <div class="row justify-content-center">
                 <div class="col-lg-8">    

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1049,7 +1049,7 @@ const consentSubmit = async e => {
     formData['982402227'] = CSDate.split('/')[2]+CSDate.split('/')[0]+CSDate.split('/')[1];
     formData['query.firstName'] = [CSFirstName.value.trim().toLowerCase()];
     formData['query.lastName'] = [CSLastName.value.trim().toLowerCase()];
-    formData['919254129'] = 353358909;
+    formData[fieldMapping.consentSubmitted] = fieldMapping.yes;
     formData['454445267'] = dateTime();
     formData['262613359'] = dateTime();
     formData['558435199'] = 353358909;

--- a/js/pages/homePage.js
+++ b/js/pages/homePage.js
@@ -1,6 +1,7 @@
 import { getMyData, hasUserData, urls, fragment, checkAccount, validEmailFormat, validPhoneNumberFormat, getCleanSearchString, firebaseSignInRender, signInAnonymously, usGov, translateHTML, translateText, getFirebaseUI, showAnimation, hideAnimation } from "../shared.js";
 import { signInConfig } from "./signIn.js";
 import { environmentWarningModal, downtimeWarning } from "../event.js";
+import fieldMapping from '../fieldToConceptIdMapping.js';
 
 /**
  * Renders homepage for sign-in/sign-up 
@@ -129,13 +130,13 @@ export const whereAmIInDashboard = async () => {
     if(!hasUserData(myData)) return '';
     
     let data = myData.data;
-    if(data['827220437'] && data['142654897']){
-        if(data['919254129'] === 353358909){
-            if(data['699625233'] && data['699625233'] === 353358909 && data['821247024'] && data['821247024'] !== 197316935){
+    if(data[fieldMapping.healthcareProvider] && data[fieldMapping.heardAboutStudyForm]){
+        if(data[fieldMapping.consentSubmitted] === fieldMapping.yes){
+            if(data[fieldMapping.userProfileSubmittedAutogen] && data[fieldMapping.userProfileSubmittedAutogen] === fieldMapping.yes && data[fieldMapping.verification] && data[fieldMapping.verification] !== fieldMapping.verified){
                 //Awaiting verification
               return translateText('home.awaitVerification');
             }
-            if(data['699625233'] && data['699625233'] === 353358909){
+            if(data[fieldMapping.userProfileSubmittedAutogen] && data[fieldMapping.userProfileSubmittedAutogen] === fieldMapping.yes){
                 
                 //go do your surveys
               return translateText('home.doSurveys');
@@ -146,11 +147,11 @@ export const whereAmIInDashboard = async () => {
         //sign e-consent
         return translateText('home.signConsent');
     }
-    else if(data['827220437'] && !data['142654897']){
+    else if(data[fieldMapping.healthcareProvider] && !data[fieldMapping.heardAboutStudyForm]){
         //heard about study
         return translateText('home.heardStudy')
     }
-    else if(data['379080287']){
+    else if(data[fieldMapping.pinNumber]){
         //pin
         return translateText('home.havePin')
     }

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -17,19 +17,13 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
     }
 
     // Completed healthcareProvider and heardAboutStudy forms
-    if(data['827220437'] && data['142654897']){
-        localStorage.eligibilityQuestionnaire = JSON.stringify({'827220437': data['827220437']})
-        if(data['919254129'] === 353358909){
+    if (data[fieldMapping.healthcareProvider] && data[fieldMapping.heardAboutStudyForm]) {
+        localStorage.eligibilityQuestionnaire = JSON.stringify({[fieldMapping.healthcareProvider]: data[fieldMapping.healthcareProvider]})
+        if(data[fieldMapping.consentSubmitted] === fieldMapping.yes) {
 
-            if (data['699625233'] === 353358909 && data['512820379'] === 854703046 && data['821247024'] === 875007964) {
-                blockParticipant();
-                hideAnimation();
-                return;
-            }
-            
-            let topMessage = "";
+            let topMessage = ""; 
+            if(data[fieldMapping.userProfileSubmittedAutogen] && data[fieldMapping.userProfileSubmittedAutogen] === fieldMapping.yes){
 
-            if(data['699625233'] && data['699625233'] === 353358909){
                 let template = `
                     <div class="row">
                         <div class="col-xl-2">
@@ -43,8 +37,8 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                 if (isParticipantDataDestroyed(data)){
                     finalMessage += '<span data-i18n="mytodolist.deletedData">At your request, we have deleted your Connect data. If you have any questions, please contact the Connect Support Center by calling 1-877-505-0253 or by emailing  <a href="mailto:ConnectSupport@norc.org">ConnectSupport@norc.org</a>.</span>'
                 }
-                else if (data['831041022'] === 353358909){
-                    if (!data['359404406'] || data['359404406'] == fieldMapping.no){
+                else if (data[fieldMapping.destroyData] === fieldMapping.yes) {
+                    if (!data[fieldMapping.destroyDataSigned] || data[fieldMapping.destroyDataSigned] == fieldMapping.no){
                         finalMessage += '<span data-i18n="mytodolist.newFormSign">You have a new <a href="#forms">form</a> to sign.</span>' + defaultMessage
                     }
                     else if((data[fieldMapping.consentWithdrawn] && data[fieldMapping.consentWithdrawn] !== fieldMapping.no) && (!data[fieldMapping.hipaaRevocationSigned] || data[fieldMapping.hipaaRevocationSigned] == fieldMapping.no)){
@@ -63,6 +57,11 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                         finalMessage += defaultMessage
                     }
                 }
+                else if (data[fieldMapping.recruitmentType] === fieldMapping.recruitmentTypePassive && data[fieldMapping.verification] === fieldMapping.notYetVerified) {
+                    blockParticipant();
+                    hideAnimation();
+                    return;
+                }
                 if(finalMessage.trim() !== ""){
                     template += `
                     <div class="alert alert-warning" role="alert" aria-live="polite" id="verificationMessage" style="margin-top:10px;">
@@ -76,7 +75,7 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                 else if (((data[fieldMapping.revokeHipaa] === fieldMapping.yes)) && (!data[fieldMapping.hipaaRevocationSigned] || data[fieldMapping.hipaaRevocationSigned] === fieldMapping.no)){
                     topMessage += '<span data-i18n="mytodolist.newFormSign">You have a new <a href="#forms">form</a> to sign.</span><p/><br>';
                 }
-                if(!data['821247024'] || data['821247024'] == 875007964){
+                if(!data[fieldMapping.verification] || data[fieldMapping.verification] == fieldMapping.notYetVerified){
                     if(data['unverifiedSeen'] && data['unverifiedSeen'] === true){
                         topMessage += '';
                     }
@@ -92,7 +91,7 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                             ${checkIfComplete(data) ? '<span data-i18n="mytodolist.thankYouCompleting">Thank you for completing your first Connect survey! We will be in touch with next steps.</span>': '<span data-i18n="mytodolist.firstSurvey">In the meantime, please begin by completing your first Connect survey.</span>'}`}
                     `
                 }
-                else if(data['821247024'] && data['821247024'] == 197316935) {
+                else if(data[fieldMapping.verification] && data[fieldMapping.verification] == fieldMapping.verified) {
                     if(data['verifiedSeen'] && data['verifiedSeen'] === true){
                         if(checkIfComplete(data)) {
                             if(!data['firstSurveyCompletedSeen']) {
@@ -120,7 +119,7 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                         storeResponse(formData);
                     }
                 }
-                else if(data['821247024'] && data['821247024'] == 219863910) {
+                else if(data[fieldMapping.verification] && data[fieldMapping.verification] == fieldMapping.cannotBeVerified) {
                     template += `
                     <div class="alert alert-warning" role="alert" aria-live="polite" id="verificationMessage" style="margin-top:10px;"  data-i18n="mytodolist.notEligibleMessage">
                         Based on our records you are not eligible for the Connect for Cancer Prevention Study. Thank you for your interest. Any information that you have already provided will remain private. We will not use any information you shared for our research.
@@ -136,7 +135,7 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                     hideAnimation();
                     return;
                 }
-                else if(data['821247024'] && data['821247024'] == 922622075) {
+                else if(data[fieldMapping.verification] && data[fieldMapping.verification] == fieldMapping.duplicate) {
                     template += `
                     <div class="alert alert-warning" role="alert" aria-live="polite" id="verificationMessage" style="margin-top:10px;" data-i18n="mytodolist.alreadyHaveAccount">
                         Our records show that you already have another account with a different email or phone number. Please try signing in again. Contact the Connect Support Center by emailing <a href = "mailto:ConnectSupport@norc.org">ConnectSupport@norc.org</a> or calling <span style="white-space:nowrap;overflow:hidden">1-877-505-0253</span> if you need help accessing your account.
@@ -281,9 +280,9 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
         consentTemplate();
         hideAnimation();
         return;
-    }
+                  }
     // Completed healthcareProvider form. Did not complete heardAboutStudy form.
-    else if(data['827220437'] && !data['142654897'] && !isParticipantDataDestroyed(data)){
+    else if(data[fieldMapping.healthcareProvider] && !data[fieldMapping.heardAboutStudyForm] && !isParticipantDataDestroyed(data)){
         mainContent.innerHTML =  heardAboutStudy();
         addEventHeardAboutStudy();
         hideAnimation();
@@ -348,7 +347,7 @@ const renderMainBody = async (data, collections, tab) => {
         },
         { body: ["Enter SSN"] },
     ];
-    if (data["821247024"] === 875007964) {
+    if (data[fieldMapping.verification] === fieldMapping.notYetVerified) {
         toDisplaySystem = [
             {
                 header: "First Survey",
@@ -854,7 +853,7 @@ const setModuleAttributes = async (data, modules, collections) => {
         modules['Covid-19'].enabled = true;
     }
 
-    if (data[fieldMapping.menstrualSurveyEligible] === 353358909) {
+    if (data[fieldMapping.menstrualSurveyEligible] === fieldMapping.yes) {
         modules['Menstrual Cycle'].enabled = true;
 
         if (data[fieldMapping.MenstrualCycle.statusFlag] !== fieldMapping.moduleStatus.submitted) {

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -135,7 +135,7 @@ export const renderSettingsPage = async () => {
     if (userData[cId.userProfileSubmittedAutogen] === cId.yes) {
       let headerMessage = '';
       if (!isParticipantDataDestroyed) {
-        if (userData[cId.verification] !== cId.verified) {
+        if (userData[cId.verification] !== cId.verified && userData[cId.consentWithdrawn] !== cId.yes) {
             headerMessage = 'settings.joinMessage';
         }
       } else {

--- a/js/pages/support.js
+++ b/js/pages/support.js
@@ -1,4 +1,5 @@
 import { getMyData, hasUserData, translateHTML, translateText } from "../shared.js";
+import fieldMapping from '../fieldToConceptIdMapping.js';
 
 export const renderSupportPage = async () => {
     document.title = translateText('support.title');
@@ -10,7 +11,7 @@ export const renderSupportPage = async () => {
     if(hasUserData(myData)){
         let data = myData.data;
         
-        if(!(data['827220437'] && data['142654897'] && data['919254129'] !== 353358909)){
+        if(!(data[fieldMapping.healthcareProvider] && data[fieldMapping.heardAboutStudyForm] && data[fieldMapping.consentSubmitted] !== fieldMapping.yes)){
             link="https://norcfedramp.servicenowservices.com/participant"
             phone = 'signedInPhone';
         }


### PR DESCRIPTION
For Issue: https://github.com/episphere/connect/issues/1334

Several places I updated the hard coded values for references to the field mapping to make the logic more readable

For the issue there are two main logic changes:
1) In myToDoList.js the logic to check and see if the passive participant is verified has been moved down from before the check for dataDestruction and consentWithdrawn to after.
2) In settings.js the logic to display the verification message also checks to see if the participant has withdrawn consent to mirror the logic for the editability of the page