### PR TITLE
Collapse the header on small screens

### DIFF
--- a/app.js
+++ b/app.js
@@ -536,6 +536,10 @@ const toggleNavBar = (route, data) => {
             showAnimation();
             document.getElementById('userNavBarContainer').innerHTML = userNavBar(data);
             document.getElementById('headerNavBarContainer').innerHTML = userHeaderNavBar(data);
+            document.getElementById('headerNavBarToggler').classList.remove("d-none");
+            document.getElementById('userNavBarToggler').classList.add("d-none");
+            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.add("navbar-expand");
+            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.remove("navbar-expand-sm");
             addMessageCounterToNavBar();
             document.getElementById('joinNow') ? document.getElementById('joinNow').innerHTML = joinNowBtn(false) : ``; 
             document.getElementById('signInWrapperDiv') ? document.getElementById('signInWrapperDiv').style.display = "none" :'';
@@ -549,6 +553,10 @@ const toggleNavBar = (route, data) => {
             showAnimation();
             document.getElementById('userNavBarContainer').innerHTML = homeNavBar();
             document.getElementById('headerNavBarContainer').innerHTML = '';
+            document.getElementById('headerNavBarToggler').classList.add("d-none");
+            document.getElementById('userNavBarToggler').classList.remove("d-none");
+            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.add("navbar-expand-sm");
+            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.remove("navbar-expand");
             document.getElementById('joinNow') ? document.getElementById('joinNow').innerHTML = joinNowBtn(true) : ``;
             document.getElementById('nextStepWarning') ? document.getElementById('nextStepWarning').style.display="none": '';
             await toggleCurrentPageNoUser(route);

--- a/app.js
+++ b/app.js
@@ -539,7 +539,7 @@ const toggleNavBar = (route, data) => {
             document.getElementById('headerNavBarToggler').classList.remove("d-none");
             document.getElementById('userNavBarToggler').classList.add("d-none");
             document.getElementById('userNavBarToggler').parentNode.parentNode.classList.add("navbar-expand");
-            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.remove("navbar-expand-sm");
+            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.remove("navbar-expand-md");
             addMessageCounterToNavBar();
             document.getElementById('joinNow') ? document.getElementById('joinNow').innerHTML = joinNowBtn(false) : ``; 
             document.getElementById('signInWrapperDiv') ? document.getElementById('signInWrapperDiv').style.display = "none" :'';
@@ -555,7 +555,7 @@ const toggleNavBar = (route, data) => {
             document.getElementById('headerNavBarContainer').innerHTML = '';
             document.getElementById('headerNavBarToggler').classList.add("d-none");
             document.getElementById('userNavBarToggler').classList.remove("d-none");
-            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.add("navbar-expand-sm");
+            document.getElementById('userNavBarToggler').parentNode.parentNode.classList.add("navbar-expand-md");
             document.getElementById('userNavBarToggler').parentNode.parentNode.classList.remove("navbar-expand");
             document.getElementById('joinNow') ? document.getElementById('joinNow').innerHTML = joinNowBtn(true) : ``;
             document.getElementById('nextStepWarning') ? document.getElementById('nextStepWarning').style.display="none": '';

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                     </div>
                     <div class="col-4 d-flex justify-content-end">
                         <div id="headerNav" class="navbar navbar-dark navbar-expand-md fixed-top justify-content-end">
-                            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+                            <button id="headerNavBarToggler" class="navbar-toggler d-none" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
                                 aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
                                 <span class="navbar-toggler-icon"></span>
                             </button>
@@ -81,9 +81,13 @@
                         </div>
                     </div> 
                 </div>
-                <nav class="navbar navbar-dark navbar-expand custom-menu-color">
+                <nav class="navbar navbar-dark navbar-expand-sm custom-menu-color">
                     <div class="container-fluid">
-                        <div class="collapse navbar-collapse" id="navbarContent">
+                        <button id="userNavBarToggler" class="navbar-toggler d-none" type="button" data-bs-toggle="collapse" data-bs-target="#userNavbarContent"
+                                aria-controls="userNavbarContent" aria-expanded="false" aria-label="Toggle navigation">
+                                <span class="navbar-toggler-icon"></span>
+                            </button>
+                        <div class="collapse navbar-collapse" id="userNavbarContent">
                             <div id="userNavBarContainer" class="navbar-nav me-auto mb-2 mb-lg-0"></div>
                         </div>
                         <div id="languageSelectorContainer" class="col-auto ms-3 d-flex align-items-center"></div>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                         </div>
                     </div> 
                 </div>
-                <nav class="navbar navbar-dark navbar-expand-sm custom-menu-color">
+                <nav class="navbar navbar-dark navbar-expand-md custom-menu-color">
                     <div class="container-fluid">
                         <button id="userNavBarToggler" class="navbar-toggler d-none" type="button" data-bs-toggle="collapse" data-bs-target="#userNavbarContent"
                                 aria-controls="userNavbarContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Per the feedback the app will collapse the header into a menu on small screens when the user is not logged in to keep it from causing the language selector to be cut off