### PR TITLE
Block Participants from Non Enrolling Sites

### DIFF
--- a/i18n/en.js
+++ b/i18n/en.js
@@ -689,6 +689,8 @@ const en = {
         "nihHealth": "NIH…Turning Discovery Into Health<sup>®</sup>"
     },
     "provider": {
+        "noLongerEnrollingStart": "Thanks for your interest in Connect. Unfortunately, we are no longer enrolling participants from ",
+        "noLongerEnrollingEnd": ". We're sorry, but this means that you won't be able to join the study. If you have any questions, please feel free to contact our team at the Connect Support Center.<br><br>If you are already a Connect participant and forgot your login information or need help accessing your account, please contact the Connect Support Center so our team can assist.",
         "alertWarning": "Our records show that you already have another account with a different email or phone number. Please try signing in again. Contact the Connect Support Center by emailing <a href=\"mailto:ConnectSupport@norc.org\">ConnectSupport@norc.org</a> or calling <span style=\"white-space:nowrap;overflow:hidden\">1-877-505-0253</span> if you need help accessing your account.",
         "receivedPin": "<strong>If you received a PIN as part of your study invitation, please enter it here.<br>Your PIN should be 6 characters and will include only numbers and uppercase letters.<br></strong>",
         "enterPin": {

--- a/i18n/es.js
+++ b/i18n/es.js
@@ -693,6 +693,8 @@
         "nihHealth": "NIH…Turning Discovery Into Health<sup>®</sup>"
     },
     "provider": {
+        "noLongerEnrollingStart": "Gracias por su interés en Connect. Lamentablemente, ya no estamos inscribiendo participantes del sitio ",
+        "noLongerEnrollingEnd": ". Lo sentimos, pero esto significa que no podrá unirse al estudio. Si tiene alguna pregunta, no dude en comunicarse con nuestro equipo en el Centro de Asistencia de Connect.<br><br>Si ya es participante de Connect y ha olvidado su información de inicio de sesión o necesita ayuda para acceder a su cuenta, por favor comunicarse con el Centro de Asistencia de Connect para que nuestro equipo pueda asistirle.",
         "alertWarning": "Nuestros registros muestran que ya tiene otra cuenta con una dirección de correo electrónico o número de teléfono diferente. Intente iniciar sesión de nuevo. Si necesita ayuda para acceder a su cuenta, escriba al Centro de Asistencia de Connect a <a href=\"mailto:ConnectAyuda@norc.org\">ConnectAyuda@norc.org</a> o llame al <span style=\"white-space:nowrap;overflow:hidden\">1-877-775-7004</span>.",
         "receivedPin": "<strong>Si recibió un PIN como parte de su invitación al estudio, ingréselo aquí.<br/>Su PIN debe tener 6 caracteres e incluir solo números y letras mayúsculas.<br/></strong>",
         "enterPin": {

--- a/js/event.js
+++ b/js/event.js
@@ -1,4 +1,4 @@
-import { allCountries, dataSavingBtn, storeResponse, validatePin, createParticipantRecord, showAnimation, hideAnimation, sites, errorMessage, BirthMonths, getAge, getMyData, hasUserData, retrieveNotifications, toggleNavbarMobileView, appState, logDDRumError, showErrorAlert, translateHTML, translateText, firebaseSignInRender, emailAddressValidation, emailValidationStatus, emailValidationAnalysis, validEmailFormat, validNameFormat, addressValidation, statesWithAbbreviations, swapKeysAndValues, escapeHTML } from "./shared.js";
+import { allCountries, dataSavingBtn, storeResponse, validatePin, createParticipantRecord, showAnimation, hideAnimation, sites, sitesNotEnrolling, errorMessage, BirthMonths, getAge, getMyData, hasUserData, retrieveNotifications, toggleNavbarMobileView, appState, logDDRumError, showErrorAlert, translateHTML, translateText, firebaseSignInRender, emailAddressValidation, emailValidationStatus, emailValidationAnalysis, validEmailFormat, validNameFormat, addressValidation, statesWithAbbreviations, swapKeysAndValues, escapeHTML } from "./shared.js";
 import { consentTemplate } from "./pages/consent.js";
 import { heardAboutStudy, healthCareProvider, duplicateAccountReminderRender, noLongerEnrollingRender,  requestPINTemplate } from "./pages/healthCareProvider.js";
 import { renderDashboard } from "./pages/dashboard.js";
@@ -205,11 +205,21 @@ export const addEventHealthCareProviderSubmit = () => {
         e.preventDefault();
         
         const value = parseInt(document.getElementById('827220437').value);
+
+        if (sitesNotEnrolling()[value]) {
+            let modalBody = document.getElementById('HealthProviderNotEnrollingModalBody');
+            let modalButton = document.getElementById('openNotEnrollingModal');
+            modalBody.innerHTML = translateHTML(`<span data-i18n="provider.noLongerEnrollingStart">Thanks for your interest in Connect. Unfortunately, we are no longer enrolling participants from </span>${sites()[value]}<span data-i18n="provider.noLongerEnrollingEnd">. We're sorry, but this means that you won't be able to join the study. If you have any questions, please feel free to contact our team at the Connect Support Center.
+                <br><br>
+                If you are already a Connect participant and forgot your login information or need help accessing your account, please contact the Connect Support Center so our team can assist.</span>`);
+            modalButton.click();
+        } else {
+            let modalBody = document.getElementById('HealthProviderModalBody');
+            let modalButton = document.getElementById('openModal');
+            modalBody.innerHTML = translateHTML(`<span data-i18n="event.sureAboutProvider">Are you sure </span>${sites()[value]}<span data-i18n="event.sureAboutProviderEnd"> is your healthcare provider?</span>`);
+            modalButton.click();
+        }
         
-        let modalBody = document.getElementById('HealthProviderModalBody');
-        let modalButton = document.getElementById('openModal');
-        modalBody.innerHTML = translateHTML(`<span data-i18n="event.sureAboutProvider">Are you sure </span>${sites()[value]}<span data-i18n="event.sureAboutProviderEnd"> is your healthcare provider?</span>`);
-        modalButton.click();
     });
 }
 
@@ -2137,7 +2147,7 @@ export const addEventRequestPINForm = () => {
         let pathAfterPINSubmission;
         let validatePinResponse;
         let createParticipantRecordResponse;
-        let healthcareProvider;
+        let healthCareProviderId;
 
         try {
             showAnimation();
@@ -2163,7 +2173,7 @@ export const addEventRequestPINForm = () => {
                 pathAfterPINSubmission = 'duplicateAccountReminder';
 
             // No Longer Enrolling at this Location
-            } else if (validatePinResponse && validatePinResponse.code === 204) {
+            } else if (validatePinResponse && validatePinResponse.code === 286) {
                 pathAfterPINSubmission = 'noLongerEnrolling';
                 healthCareProviderId = validatePinResponse.message;
 

--- a/js/event.js
+++ b/js/event.js
@@ -2137,6 +2137,7 @@ export const addEventRequestPINForm = () => {
         let pathAfterPINSubmission;
         let validatePinResponse;
         let createParticipantRecordResponse;
+        let healthcareProvider;
 
         try {
             showAnimation();
@@ -2160,6 +2161,11 @@ export const addEventRequestPINForm = () => {
             // Duplicate account. Route participant to the duplicate account reminder form.
             } else if (validatePinResponse && validatePinResponse.code === 202) {
                 pathAfterPINSubmission = 'duplicateAccountReminder';
+
+            // No Longer Enrolling at this Location
+            } else if (validatePinResponse && validatePinResponse.code === 204) {
+                pathAfterPINSubmission = 'noLongerEnrolling';
+                healthCareProvider = validatePinResponse.message;
 
             // Invalid PIN, no PIN entered, or error (validatePIN failed). Create a new participant record and store the entered PIN regardless of its validity.
             } else {
@@ -2195,7 +2201,7 @@ export const addEventRequestPINForm = () => {
         } finally {
             await storeParameters();
             hideAnimation();
-            loadPathFromPINForm(pathAfterPINSubmission);
+            loadPathFromPINForm(pathAfterPINSubmission, healthCareProvider);
         }
     });
 }
@@ -2296,6 +2302,10 @@ const loadPathFromPINForm = (path) => {
 
         case 'duplicateAccountReminder':
             duplicateAccountReminderRender();
+            break;
+
+        case 'noLongerEnrolling':
+            noLongerEnrollingRender();
             break;
 
         case 'heardAboutStudy':

--- a/js/event.js
+++ b/js/event.js
@@ -1,6 +1,6 @@
 import { allCountries, dataSavingBtn, storeResponse, validatePin, createParticipantRecord, showAnimation, hideAnimation, sites, errorMessage, BirthMonths, getAge, getMyData, hasUserData, retrieveNotifications, toggleNavbarMobileView, appState, logDDRumError, showErrorAlert, translateHTML, translateText, firebaseSignInRender, emailAddressValidation, emailValidationStatus, emailValidationAnalysis, validEmailFormat, validNameFormat, addressValidation, statesWithAbbreviations, swapKeysAndValues, escapeHTML } from "./shared.js";
 import { consentTemplate } from "./pages/consent.js";
-import { heardAboutStudy, healthCareProvider, duplicateAccountReminderRender, requestPINTemplate } from "./pages/healthCareProvider.js";
+import { heardAboutStudy, healthCareProvider, duplicateAccountReminderRender, noLongerEnrollingRender,  requestPINTemplate } from "./pages/healthCareProvider.js";
 import { renderDashboard } from "./pages/dashboard.js";
 import { suffixToTextMap, getFormerNameData, formerNameOptions } from "./settingsHelpers.js";
 import fieldMapping from "./fieldToConceptIdMapping.js";
@@ -2165,7 +2165,7 @@ export const addEventRequestPINForm = () => {
             // No Longer Enrolling at this Location
             } else if (validatePinResponse && validatePinResponse.code === 204) {
                 pathAfterPINSubmission = 'noLongerEnrolling';
-                healthCareProvider = validatePinResponse.message;
+                healthCareProviderId = validatePinResponse.message;
 
             // Invalid PIN, no PIN entered, or error (validatePIN failed). Create a new participant record and store the entered PIN regardless of its validity.
             } else {
@@ -2201,7 +2201,7 @@ export const addEventRequestPINForm = () => {
         } finally {
             await storeParameters();
             hideAnimation();
-            loadPathFromPINForm(pathAfterPINSubmission, healthCareProvider);
+            loadPathFromPINForm(pathAfterPINSubmission, healthCareProviderId);
         }
     });
 }
@@ -2284,7 +2284,7 @@ export const getFirstSignInISOTime = async () => {
  * @param { string } path - The path to load after the PIN form.
  */
 
-const loadPathFromPINForm = (path) => {
+const loadPathFromPINForm = (path, healthCareProviderId) => {
     const mainContent = document.getElementById('root');
     if (!mainContent) {
         console.error('loadPathFromPINForm(): Could not find mainContent element');
@@ -2305,7 +2305,7 @@ const loadPathFromPINForm = (path) => {
             break;
 
         case 'noLongerEnrolling':
-            noLongerEnrollingRender();
+            noLongerEnrollingRender(healthCareProviderId);
             break;
 
         case 'heardAboutStudy':

--- a/js/pages/dashboard.js
+++ b/js/pages/dashboard.js
@@ -1,9 +1,9 @@
-import { allocateDHQ3Credential, hideAnimation, questionnaireModules, storeResponse, isParticipantDataDestroyed, translateHTML, translateText, getAdjustedTime, getAppSettings, logDDRumError, reportConfiguration, setReportAttributes, updateStartDHQParticipantData } from "../shared.js";
+import { allocateDHQ3Credential, hideAnimation, questionnaireModules, storeResponse, isParticipantDataDestroyed, translateHTML, translateText, getAdjustedTime, getAppSettings, logDDRumError, reportConfiguration, setReportAttributes, updateStartDHQParticipantData, sitesNotEnrolling } from "../shared.js";
 import { blockParticipant, questionnaire } from "./questionnaire.js";
 import { renderUserProfile } from "../components/form.js";
 import { consentTemplate } from "./consent.js";
 import { addEventHeardAboutStudy, addEventRequestPINForm, addEventHealthCareProviderSubmit, addEventPinAutoUpperCase, addEventHealthProviderModalSubmit, addEventToggleSubmit, storeParameters } from "../event.js";
-import { heardAboutStudy, requestPINTemplate, healthCareProvider } from "./healthCareProvider.js";
+import { heardAboutStudy, requestPINTemplate, healthCareProvider, noLongerEnrollingRender } from "./healthCareProvider.js";
 import fieldMapping from '../fieldToConceptIdMapping.js';
 
 export const renderDashboard = async (data, fromUserProfile, collections) => {
@@ -224,12 +224,21 @@ export const renderDashboard = async (data, fromUserProfile, collections) => {
                 hideAnimation();
                 return;
             }
-            renderUserProfile();
+
+            if (sitesNotEnrolling()[data[fieldMapping.healthcareProvider]]) {
+                noLongerEnrollingRender(data[fieldMapping.healthcareProvider]);
+            } else {
+                renderUserProfile();
+            }
             hideAnimation();
             return;
         }
 
-        consentTemplate();
+        if (sitesNotEnrolling()[data[fieldMapping.healthcareProvider]]) {
+            noLongerEnrollingRender(data[fieldMapping.healthcareProvider]);
+        } else {
+            consentTemplate();
+        }
         hideAnimation();
         return;
     }

--- a/js/pages/healthCareProvider.js
+++ b/js/pages/healthCareProvider.js
@@ -11,6 +11,20 @@ export const duplicateAccountReminderRender = () => {
   `);
 };
 
+export const noLongerEnrollingRender = (healthCareProviderId) => {
+  let site = sites()[healthCareProviderId];
+  document.getElementById('root').innerHTML = translateHTML(`
+    <div class="row justify-content-cent er mt-3">
+      <div class="col-lg-8 alert alert-warning" data-i18n="provider.noLongerEnrolling">
+        <span data-i18n="provider.noLongerEnrollingStart">Thanks for your interest in Connect. Unfortunately, we are no longer enrolling participants from </span>${site}
+        <span data-i18n="provider.noLongerEnrollingEnd">. We're sorry, but this means that you won't be able to join the study. If you have any questions, please feel free to contact our team at the Connect Support Center.
+        <br><br>
+        If you are already a Connect participant and forgot your login information or need help accessing your account, please contact the Connect Support Center so our team can assist.</span>
+      </div>
+    </div>
+  `);
+};
+
 export const requestPINTemplate = () => {
     return translateHTML(`
         <br>

--- a/js/pages/healthCareProvider.js
+++ b/js/pages/healthCareProvider.js
@@ -15,9 +15,8 @@ export const noLongerEnrollingRender = (healthCareProviderId) => {
   let site = sites()[healthCareProviderId];
   document.getElementById('root').innerHTML = translateHTML(`
     <div class="row justify-content-cent er mt-3">
-      <div class="col-lg-8 alert alert-warning" data-i18n="provider.noLongerEnrolling">
-        <span data-i18n="provider.noLongerEnrollingStart">Thanks for your interest in Connect. Unfortunately, we are no longer enrolling participants from </span>${site}
-        <span data-i18n="provider.noLongerEnrollingEnd">. We're sorry, but this means that you won't be able to join the study. If you have any questions, please feel free to contact our team at the Connect Support Center.
+      <div class="col-lg-8 offset-lg-2 alert alert-warning">
+        <span data-i18n="provider.noLongerEnrollingStart">Thanks for your interest in Connect. Unfortunately, we are no longer enrolling participants from </span>${site}<span data-i18n="provider.noLongerEnrollingEnd">. We're sorry, but this means that you won't be able to join the study. If you have any questions, please feel free to contact our team at the Connect Support Center.
         <br><br>
         If you are already a Connect participant and forgot your login information or need help accessing your account, please contact the Connect Support Center so our team can assist.</span>
       </div>
@@ -60,23 +59,42 @@ export const healthCareProvider = (siteId) => {
     <br>
     <!-- Modal -->
     <div class="modal fade" id="HealthProviderModal" tabindex="-1" role="dialog" aria-labelledby="HealthProviderModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-        <div class="modal-header">
-            <h5 class="modal-title" id="HealthProviderModalLabel"></h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-            
-            </button>
-        </div>
-        <div class="modal-body" id="HealthProviderModalBody">
-            ...
-        </div>
-        <div class="modal-footer">
-            <button type="button" id="modalCancel" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="provider.modalCancel">No</button>
-            <button type="button" id="modalConfirm" class="btn btn-primary consentNextButton" data-i18n="provider.modalConfirm">Yes</button>
-        </div>
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="HealthProviderModalLabel"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                
+                </button>
+            </div>
+            <div class="modal-body" id="HealthProviderModalBody">
+                ...
+            </div>
+            <div class="modal-footer">
+                <button type="button" id="modalCancel" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="provider.modalCancel">No</button>
+                <button type="button" id="modalConfirm" class="btn btn-primary consentNextButton" data-i18n="provider.modalConfirm">Yes</button>
+            </div>
+            </div>
         </div>
     </div>
+    <!-- Not Enrolling Modal -->
+    <div class="modal fade" id="HealthProviderNotEnrollingModal" tabindex="-1" role="dialog" aria-labelledby="HealthProviderNotEnrollingModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="HealthProviderNotEnrollingModalLabel"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                
+                </button>
+            </div>
+            <div class="modal-body" id="HealthProviderNotEnrollingModalBody">
+                ...
+            </div>
+            <div class="modal-footer">
+                <button type="button" id="modalConfirm" class="btn btn-primary consentNextButton" data-bs-dismiss="modal" data-i18n="shared.closeText">Close</button>
+            </div>
+            </div>
+        </div>
     </div>
     <div class = "row">
     <div class="col-lg-2">
@@ -101,6 +119,7 @@ export const healthCareProvider = (siteId) => {
                 <span class="required" data-i18n="provider.required">*Required</span>
                 <div>
                     <button style="display:none;" id="openModal" class="btn btn-primary save-data consentNextButton" data-bs-toggle="modal" data-bs-target="#HealthProviderModal" data-i18n="provider.submitText">Submit</button>
+                    <button style="display:none;" id="openNotEnrollingModal" class="btn btn-primary save-data consentNextButton" data-bs-toggle="modal" data-bs-target="#HealthProviderNotEnrollingModal" data-i18n="provider.submitText">Submit</button>
                     <button type="submit" class="btn btn-primary save-data consentNextButton" data-i18n="provider.submitText">Submit</button>
                 </div>
             </div>

--- a/js/shared.js
+++ b/js/shared.js
@@ -606,6 +606,25 @@ export const sites = () => {
     }
 }
 
+export const sitesNotEnrolling = () => {
+    if(location.host === urls.prod) {
+        return {
+            809703864: 'University of Chicago Medicine',
+        }
+    }
+    else if (location.host === urls.stage) {
+        return {
+            809703864: 'University of Chicago Medicine',
+        }
+        //return allIHCS
+    }
+    else{
+        return { 
+             809703864: 'University of Chicago Medicine',
+         }
+    }
+}
+
 export const siteAcronyms = () => {
     return {
         531629870: 'HP',

--- a/js/shared.js
+++ b/js/shared.js
@@ -616,7 +616,6 @@ export const sitesNotEnrolling = () => {
         return {
             809703864: 'University of Chicago Medicine',
         }
-        //return allIHCS
     }
     else{
         return { 


### PR DESCRIPTION
For Issue 1423: https://github.com/episphere/connect/issues/1423

If the validatePin returns a not enrolling code then the participant is redirected to a message and can not proceed
If the user selects a non enrolling provider they will be presented with a message modal and can not proceed
If the user has already selected a provider but has not consented or finished the profile they will be presented with a warning message and will not be able to proceed